### PR TITLE
upgrade pybboxes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ shapely>=1.8.0
 tqdm>=4.48.2
 pillow>=8.2.0
 pybboxes==0.1.5; python_version < '3.8'
-pybboxes==0.1.5; python_version >= '3.8'
+pybboxes==0.1.6; python_version >= '3.8'
 pyyaml
 fire
 terminaltables


### PR DESCRIPTION
`pybboxes==0.1.5` has a typo in its setup.py file so upgrading one minor version to resolve.